### PR TITLE
fix: prevent double fetchDatas call at initialization

### DIFF
--- a/src/useDatatableUrlSync.ts
+++ b/src/useDatatableUrlSync.ts
@@ -317,6 +317,11 @@ export default function useDatatableUrlSync(route: any, router: any, form: Ref<G
       initializeForm();
     }
 
+    localQuery = {
+      ...generateQueryFromObject(form.value, formSchema, false),
+      ...generateQueryFromObject(options.value, formSchema, false),
+    }
+
     getDatas()
   }
 


### PR DESCRIPTION
There was a double fetchDatas call, first in `initializeFromRouter` then in the options watcher